### PR TITLE
HOTFIX: Pin commit for `get-poetry.py` script because it has been removed in `master` branch.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ log "Generate requirements.txt with Poetry"
 
 log "Install Poetry"
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/d222411ae9d01a04ec8eda348a65aa83852c37d0/get-poetry.py \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent


### PR DESCRIPTION
The `get-poetry.py` script has been deprecated for a while. They finally removed it [2 days ago](https://github.com/python-poetry/poetry/commit/82eb9346e0b8c9523067a926230d67bccaa59b50).
For now, we'll just pin to the commit before it was removed.